### PR TITLE
feat(packages): specify version of packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13438,7 +13438,7 @@
     },
     "packages/cli": {
       "name": "confiks",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2 || ^5.3.0",

--- a/packages/cli/src/components/choices/package.choice.ts
+++ b/packages/cli/src/components/choices/package.choice.ts
@@ -54,8 +54,11 @@ export class PackageChoice extends BaseChoice implements Choice {
     this.message = packageModel.title;
     this.value = packageModel;
     if (options?.hint) this.hint = options.hint;
+    if (packageModel.description)
+      this.hint = `(v${packageModel.version}) ${
+        packageModel.description || ''
+      }`;
     if (options?.indent) this.indent = options.indent;
-    if (packageModel.description) this.hint = packageModel.description;
     if (packageModel.extensions?.length)
       this.#makeChildrenChoices(packageModel.extensions);
   }

--- a/packages/cli/src/components/packages/base.package.spec.ts
+++ b/packages/cli/src/components/packages/base.package.spec.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { DependencyTypeEnum } from '../../type/enums/dependency-type.enum.js';
+import { VersionRange } from '../../type/types/package-version.type';
 import { BasePackage } from './base.package.js';
 
 class Mock extends BasePackage {
   readonly dependencyType = DependencyTypeEnum.dependency;
   readonly title = 'Mock';
   readonly package = 'husky';
+  readonly version: VersionRange = '1.0.0';
 
   configure(): void {
     // empty
@@ -21,5 +23,11 @@ describe('BasePackage', () => {
 
   test('should create instance', () => {
     expect(fixture).toBeDefined();
+  });
+
+  test('returns correct dependency string', () => {
+    const mockPackage = new Mock();
+
+    expect(mockPackage.dependency).toBe('husky@"1.0.0"');
   });
 });

--- a/packages/cli/src/components/packages/base.package.ts
+++ b/packages/cli/src/components/packages/base.package.ts
@@ -1,6 +1,10 @@
 import type { DependencyTypeEnum } from '../../type/enums/dependency-type.enum.js';
 import type { PackagesEnumKeys } from '../../type/enums/packages.enum.js';
 import type { PackageInterface } from '../../type/interfaces/package.interface.js';
+import type {
+  Dependency,
+  VersionRange,
+} from '../../type/types/package-version.type.js';
 
 /**
  * This is base abstract class to create new packages that you can install in your project
@@ -12,5 +16,10 @@ import type { PackageInterface } from '../../type/interfaces/package.interface.j
 export abstract class BasePackage implements PackageInterface {
   abstract readonly title: string;
   abstract readonly package: PackagesEnumKeys;
+  abstract readonly version: VersionRange;
   abstract readonly dependencyType: DependencyTypeEnum;
+
+  get dependency(): Dependency {
+    return `${this.package}@"${this.version}"`;
+  }
 }

--- a/packages/cli/src/components/packages/commit-lint/commit-lint.package.ts
+++ b/packages/cli/src/components/packages/commit-lint/commit-lint.package.ts
@@ -12,6 +12,7 @@ import { ConfigConventionalPackage } from './config-conventional.package.js';
 export class CommitLintPackage extends BasePackage {
   readonly title = 'commitLint 📔';
   readonly package = '@commitlint/cli';
+  readonly version = '18';
   readonly extensions = [new ConfigConventionalPackage()];
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'Helps your team adhere to a commit convention.';

--- a/packages/cli/src/components/packages/commit-lint/config-conventional.package.ts
+++ b/packages/cli/src/components/packages/commit-lint/config-conventional.package.ts
@@ -4,6 +4,7 @@ import { BasePackage } from '../base.package.js';
 export class ConfigConventionalPackage extends BasePackage {
   readonly title = 'config-conventional';
   readonly package = '@commitlint/config-conventional';
+  readonly version = '18';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description =
     'Shareable commit-lint config enforcing conventional commits.';

--- a/packages/cli/src/components/packages/eslint/eslint-plugin-prettier/eslint-plugin-prettier.package.ts
+++ b/packages/cli/src/components/packages/eslint/eslint-plugin-prettier/eslint-plugin-prettier.package.ts
@@ -4,6 +4,7 @@ import { BasePackage } from '../../base.package.js';
 export class EslintPluginPrettierPackage extends BasePackage {
   readonly title = 'eslint-plugin-prettier 🖌️';
   readonly package = 'eslint-plugin-prettier';
+  readonly version = '5';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description =
     'Runs Prettier as an ESLint rule and reports differences as individual ESLint issues.';

--- a/packages/cli/src/components/packages/eslint/eslint-plugin-simple-import-sort/eslint-plugin-simple-import-sort.package.ts
+++ b/packages/cli/src/components/packages/eslint/eslint-plugin-simple-import-sort/eslint-plugin-simple-import-sort.package.ts
@@ -4,6 +4,7 @@ import { BasePackage } from '../../base.package.js';
 export class EslintPluginSimpleImportSortPackage extends BasePackage {
   readonly title = 'eslint-plugin-simple-import-sort ↕️';
   readonly package = 'eslint-plugin-simple-import-sort';
+  readonly version = '10';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'Easy autofixable import sorting.';
 }

--- a/packages/cli/src/components/packages/eslint/eslint-plugin-unicorn/eslint-plugin-unicorn.package.ts
+++ b/packages/cli/src/components/packages/eslint/eslint-plugin-unicorn/eslint-plugin-unicorn.package.ts
@@ -4,6 +4,7 @@ import { BasePackage } from '../../base.package.js';
 export class EslintPluginUnicornPackage extends BasePackage {
   readonly title = 'eslint-plugin-unicorn 🦄';
   readonly package = 'eslint-plugin-unicorn';
+  readonly version = '49';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'More than 100 powerful ESLint rules';
 }

--- a/packages/cli/src/components/packages/eslint/eslint-plugin-unused-imports/eslint-plugin-unused-imports.package.ts
+++ b/packages/cli/src/components/packages/eslint/eslint-plugin-unused-imports/eslint-plugin-unused-imports.package.ts
@@ -4,6 +4,7 @@ import { BasePackage } from '../../base.package.js';
 export class EslintPluginUnusedImportsPackage extends BasePackage {
   readonly title = 'eslint-plugin-unused-imports 🚮';
   readonly package = 'eslint-plugin-unused-imports';
+  readonly version = '3';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'Find and remove unused es6 module imports.';
 }

--- a/packages/cli/src/components/packages/eslint/eslint.package.ts
+++ b/packages/cli/src/components/packages/eslint/eslint.package.ts
@@ -11,6 +11,7 @@ import { EslintPluginUnusedImportsPackage } from './eslint-plugin-unused-imports
 export class EslintPackage extends BasePackage {
   readonly title = 'ESLint';
   readonly package = 'eslint';
+  readonly version = '8';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description =
     'is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code. (SUPPORTED: json)';

--- a/packages/cli/src/components/packages/husky/husky.package.ts
+++ b/packages/cli/src/components/packages/husky/husky.package.ts
@@ -8,6 +8,7 @@ import { BasePackage } from '../base.package.js';
 export class HuskyPackage extends BasePackage {
   readonly title = 'Husky 🐶';
   readonly package = 'husky';
+  readonly version = '8';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'Husky improves your commits and more woof!';
 

--- a/packages/cli/src/components/packages/lint-staged/lint-staged.package.ts
+++ b/packages/cli/src/components/packages/lint-staged/lint-staged.package.ts
@@ -12,6 +12,7 @@ import { HuskyPackage } from '../husky/husky.package.js';
 export class LintStagedPackage extends BasePackage {
   readonly title = '🚫💩 lint-staged';
   readonly package = 'lint-staged';
+  readonly version = '15';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description =
     "Run linters against staged git files and don't let 💩 slip into your code base!";

--- a/packages/cli/src/components/packages/prettier/prettier-plugin-organize-attributes/prettier-plugin-organize-attributes.package.ts
+++ b/packages/cli/src/components/packages/prettier/prettier-plugin-organize-attributes/prettier-plugin-organize-attributes.package.ts
@@ -5,6 +5,7 @@ import { BasePackage } from '../../base.package.js';
 export class PrettierPluginOrganizeAttributesPackage extends BasePackage {
   readonly title = 'prettier-plugin-organize-attributes 🧼';
   readonly package: PackagesEnumKeys = 'prettier-plugin-organize-attributes';
+  readonly version = '1';
   readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description =
     'Organize your HTML attributes automatically with Prettier.';

--- a/packages/cli/src/components/packages/prettier/prettier.package.ts
+++ b/packages/cli/src/components/packages/prettier/prettier.package.ts
@@ -9,8 +9,9 @@ import { PrettierPluginOrganizeAttributesPackage } from './prettier-plugin-organ
  * */
 export class PrettierPackage extends BasePackage {
   readonly title = 'Prettier 🖌️';
-  readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly package = 'prettier';
+  readonly version = '2 - 3';
+  readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly description = 'An opinionated code formatter.';
   readonly extensions = [new PrettierPluginOrganizeAttributesPackage()];
 

--- a/packages/cli/src/components/packages/pretty-quick/pretty-quick.package.ts
+++ b/packages/cli/src/components/packages/pretty-quick/pretty-quick.package.ts
@@ -8,10 +8,11 @@ import { HuskyPackage } from '../husky/husky.package.js';
  * @see https://github.com/azz/pretty-quick
  * */
 export class PrettyQuickPackage extends BasePackage {
-  readonly dependencyType = DependencyTypeEnum.devDependency;
   readonly title = 'pretty-quick';
   readonly package = 'pretty-quick';
+  readonly version = '3';
   readonly description = 'Runs Prettier on your changed files.';
+  readonly dependencyType = DependencyTypeEnum.devDependency;
 
   configure(): void {
     if (!packageIsInstalled(new HuskyPackage().package)) {

--- a/packages/cli/src/services/initializer.service.spec.ts
+++ b/packages/cli/src/services/initializer.service.spec.ts
@@ -1,5 +1,6 @@
 import { BasePackage } from '../components/packages/base.package';
 import { PackagesEnumKeys } from '../type/enums/packages.enum';
+import { VersionRange } from '../type/types/package-version.type';
 import { InitializerService } from './initializer.service';
 
 const configureMock = jest.fn();
@@ -8,6 +9,7 @@ class MockPackage extends BasePackage {
   readonly package = 'string' as PackagesEnumKeys;
   readonly title = 'string';
   configure = configureMock;
+  readonly version: VersionRange = '1.2.3';
 }
 
 describe('InitializerService', () => {

--- a/packages/cli/src/services/initializer.service.ts
+++ b/packages/cli/src/services/initializer.service.ts
@@ -12,7 +12,7 @@ export class InitializerService {
   async install(): Promise<void> {
     for (const package_ of this.packages) {
       this.#packageManagerService.addPackage(
-        package_.package,
+        package_.dependency,
         package_.dependencyType
       );
     }

--- a/packages/cli/src/services/package-managers/package-manager.service.spec.ts
+++ b/packages/cli/src/services/package-managers/package-manager.service.spec.ts
@@ -16,18 +16,21 @@ describe('PackageManagerService', () => {
 
   describe('#addPackage', () => {
     it('should add a normal dependency', () => {
-      packageManager.addPackage('husky', DependencyTypeEnum.dependency);
-      expect(packageManager['dependencies']).toContain('husky');
+      packageManager.addPackage('husky@"1"', DependencyTypeEnum.dependency);
+      expect(packageManager['dependencies']).toContain('husky@"1"');
     });
 
     it('should add a dev dependency', () => {
-      packageManager.addPackage('husky', DependencyTypeEnum.devDependency);
-      expect(packageManager['devDependencies']).toContain('husky');
+      packageManager.addPackage(
+        'husky@"latest"',
+        DependencyTypeEnum.devDependency
+      );
+      expect(packageManager['devDependencies']).toContain('husky@"latest"');
     });
 
     it('should add a global dependency', () => {
-      packageManager.addPackage('husky', DependencyTypeEnum.global);
-      expect(packageManager['global']).toContain('husky');
+      packageManager.addPackage('husky@"1 - 2"', DependencyTypeEnum.global);
+      expect(packageManager['global']).toContain('husky@"1 - 2"');
     });
   });
 

--- a/packages/cli/src/services/package-managers/package-manager.service.ts
+++ b/packages/cli/src/services/package-managers/package-manager.service.ts
@@ -1,19 +1,19 @@
 import { DependencyTypeEnum } from '../../type/enums/dependency-type.enum.js';
-import type { PackagesEnumKeys } from '../../type/enums/packages.enum.js';
 import type { PackageManager } from '../../type/interfaces/package-manager.interface.js';
+import type { Dependency } from '../../type/types/package-version.type.js';
 import { fileSystem } from '../node/file-system.service.js';
 import { NpmManagerService } from './npm-manager.service.js';
 import { PnpmManagerService } from './pnpm-manager.service.js';
 
 export class PackageManagerService {
-  private readonly dependencies: PackagesEnumKeys[] = [];
-  private readonly devDependencies: PackagesEnumKeys[] = [];
-  private readonly global: PackagesEnumKeys[] = [];
+  private readonly dependencies: Dependency[] = [];
+  private readonly devDependencies: Dependency[] = [];
+  private readonly global: Dependency[] = [];
 
   #packageManager: PackageManager = this.#selectPackageManager();
 
   addPackage(
-    packageDependency: PackagesEnumKeys,
+    packageDependency: Dependency,
     installationType: DependencyTypeEnum
   ): void {
     if (installationType === DependencyTypeEnum.dependency)

--- a/packages/cli/src/type/interfaces/package-manager.interface.ts
+++ b/packages/cli/src/type/interfaces/package-manager.interface.ts
@@ -2,13 +2,13 @@ import {
   type DependencyTypeEnum,
   type DependencyTypeEnumKeys,
 } from '../enums/dependency-type.enum.js';
-import type { PackagesEnumKeys } from '../enums/packages.enum.js';
+import type { Dependency } from '../types/package-version.type.js';
 
 export interface PackageManager {
   readonly installationType: {
     [key in DependencyTypeEnum]: string;
   };
   install(packages: {
-    [Key in DependencyTypeEnumKeys]: PackagesEnumKeys[];
+    [Key in DependencyTypeEnumKeys]: Dependency[];
   }): Promise<void>;
 }

--- a/packages/cli/src/type/interfaces/package.interface.ts
+++ b/packages/cli/src/type/interfaces/package.interface.ts
@@ -1,12 +1,18 @@
 import type { DependencyTypeEnum } from '../enums/dependency-type.enum.js';
 import type { PackagesEnumKeys } from '../enums/packages.enum.js';
+import type {
+  Dependency,
+  VersionRange,
+} from '../types/package-version.type.js';
 
 export interface PackageInterface {
   readonly package: PackagesEnumKeys;
   readonly title: string;
   readonly dependencyType: DependencyTypeEnum;
+  readonly version: VersionRange;
   readonly description?: string;
   readonly extensions?: PackageInterface[];
+  readonly dependency: Dependency;
 
   configure?: () => void;
 }

--- a/packages/cli/src/type/types/package-version.type.ts
+++ b/packages/cli/src/type/types/package-version.type.ts
@@ -1,0 +1,13 @@
+import type { PackagesEnumKeys } from '../enums/packages.enum.js';
+
+type Tag =
+  | `${number}`
+  | `${number}.${number}`
+  | `${number}.${number}.${number}`
+  | 'latest';
+
+/*
+ * @see https://docs.npmjs.com/cli/v8/commands/npm-install
+ * */
+export type VersionRange = Tag | `${Tag} - ${Tag}`;
+export type Dependency = `${PackagesEnumKeys}@"${VersionRange}"`;


### PR DESCRIPTION
Each package installed by the CLI now includes version specification. This promises more deterministic installs and provides visibility to the users. This also reduces risks of breakages due to unexpected updates.