### PR TITLE
refactor(cli/readme): sort and group packages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,19 @@ dealing with configuration complexities.
 
 ### Packages Support
 
+###### Code style
+
+- [prettier][prettier]: A code formatter.
+  - [prettier-plugin-organize-attributes][prettier-plugin-organize-attributes]: Organize your HTML attributes automatically with Prettier
+
+###### Automation
+
+- [husky][husky]: Enables Git hooks.
+- [lint-stagged][lint-stagged]: Lints only the files that are staged in Git.
+- [pretty-quick][pretty-quick]: Runs Prettier on your changed files.
+
+###### Linters
+
 - [commit-lint][commit-lint]: Enforces commit message conventions.
   - [config-conventional][config-conventional]: Shareable commit-lint config.
 - [eslint][eslint]: A pluggable linting utility for JavaScript and JSX.
@@ -32,11 +45,6 @@ dealing with configuration complexities.
   - [eslint-plugin-simple-import-sort][eslint-plugin-simple-import-sort]: Enforces a consistent import order.
   - [eslint-plugin-unicorn][eslint-plugin-unicorn]: Adds various ESLint rules for unicorn projects.
   - [eslint-plugin-unused-imports][eslint-plugin-unused-imports]: Detects and removes unused imports.
-- [husky][husky]: Enables Git hooks.
-- [lint-stagged][lint-stagged]: Lints only the files that are staged in Git.
-- [prettier][prettier]: A code formatter.
-  - [prettier-plugin-organize-attributes][prettier-plugin-organize-attributes]: Organize your HTML attributes automatically with Prettier
-- [pretty-quick][pretty-quick]: Runs Prettier on your changed files.
 
 ### Package Managers Support
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,8 +57,8 @@ async function selectPackages(): Promise<PackageInterface[]> {
     message: 'Pick automation packages to install',
     choices: [
       new PackageChoice(new HuskyPackage()),
-      new PackageChoice(new PrettyQuickPackage()),
       new PackageChoice(new LintStagedPackage()),
+      new PackageChoice(new PrettyQuickPackage()),
     ],
   });
 
@@ -66,8 +66,8 @@ async function selectPackages(): Promise<PackageInterface[]> {
     prefix: '🧹',
     message: 'Pick linter packages to install',
     choices: [
-      new PackageChoice(new EslintPackage()),
       new PackageChoice(new CommitLintPackage()),
+      new PackageChoice(new EslintPackage()),
     ],
   });
 


### PR DESCRIPTION
in CLI just sort alphabetically packages
in readme.md group packages like in CLI