### PR TITLE
fix(eslint): replace errors to warn

### DIFF
--- a/packages/cli/src/components/packages/eslint/configs/eslintrc-confiks.constant.ts
+++ b/packages/cli/src/components/packages/eslint/configs/eslintrc-confiks.constant.ts
@@ -18,8 +18,8 @@ const simpleSortConfig = (): EslintConfigPlugin =>
     ? {
         plugins: ['simple-import-sort'],
         rules: {
-          'simple-import-sort/imports': 'error',
-          'simple-import-sort/exports': 'error',
+          'simple-import-sort/imports': 'warn',
+          'simple-import-sort/exports': 'warn',
         },
       }
     : dumbConfig;
@@ -47,7 +47,7 @@ const prettierConfig = (): EslintConfigPlugin =>
         plugins: ['prettier'],
         rules: {
           'prettier/prettier': [
-            'error',
+            'warn',
             {
               endOfLine: 'auto',
             },

--- a/packages/cli/src/type/interfaces/eslint-config.interface.ts
+++ b/packages/cli/src/type/interfaces/eslint-config.interface.ts
@@ -1,7 +1,11 @@
-type Rule = boolean | string | [string, { [key: string]: boolean | string }];
+type RuleOptions = boolean | 'warn' | 'error' | 'off' | 'on';
+
+type Rule = RuleOptions | [RuleOptions, { [key: string]: boolean | string }];
+
 type Rules = {
   [key in string]: Rule;
 };
+
 export interface EslintConfig {
   root?: boolean;
   extends?: string[];


### PR DESCRIPTION
Replace errors for warns for rules:
- simple-import-sort
- prettier/prettier

because, these rules are not that important
improve typo for eslint config interface