### PR TITLE
feat(pnpm manager): add pnpm command to configure projects 

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,8 +11,14 @@ Line Interface (CLI) aids in swiftly installing essential dependencies.
 
 ![usage example][confiksDemo]
 
+###### npm
 ```shell
-npx confiks@latest
+npx confiks@latest -y
+```
+
+###### pnpm
+```shell
+pnpm dlx confiks@latest
 ```
 
 ### Why?

--- a/packages/cli/src/components/packages/base.package.ts
+++ b/packages/cli/src/components/packages/base.package.ts
@@ -25,7 +25,7 @@ export abstract class BasePackage implements PackageInterface {
     return `${this.package}@"${this.version}"`;
   }
 
-  addScripts(scripts: { [kay: string]: string }): void {
+  addScripts(scripts: { [key: string]: string }): void {
     // @example 'scripts.test="echo"'
     const parsedScripts: string = Object.entries(scripts)
       .map(([key, value]) => `scripts.${key}="${value}"`)

--- a/packages/cli/src/components/packages/biome/biome.package.ts
+++ b/packages/cli/src/components/packages/biome/biome.package.ts
@@ -1,4 +1,4 @@
-import { childProcess } from '../../../services/node/child-process.service.js';
+import { PackageManagerService } from '../../../services/package-manager/package-manager.service.js';
 import type { DependencyType } from '../../../type/types/dependency-type.type.js';
 import type { VersionRange } from '../../../type/types/package-version.type.js';
 import type { Package } from '../../../type/types/packages.type.js';
@@ -12,7 +12,11 @@ export class BiomePackage extends BasePackage {
   readonly title = 'Biome';
   readonly version: VersionRange = 'latest';
 
+  /**
+   * @see https://biomejs.dev/guides/getting-started/#configuration
+   */
+
   configure() {
-    childProcess.execSync('npx @biomejs/biome init');
+    new PackageManagerService().exec('biome init');
   }
 }

--- a/packages/cli/src/components/packages/eslint/eslint.package.spec.ts
+++ b/packages/cli/src/components/packages/eslint/eslint.package.spec.ts
@@ -2,6 +2,7 @@ import { EslintService } from '../../../services/packages/eslint/eslint.service.
 import { EslintPackage } from './eslint.package.js';
 
 jest.mock('../../../services/packages/eslint/eslint.service.js');
+jest.mock('../../../services/node/child-process.service.js');
 
 describe('EslintPackage', () => {
   let fixture: EslintPackage;

--- a/packages/cli/src/components/packages/lint-staged/lint-staged-config.constant.spec.ts
+++ b/packages/cli/src/components/packages/lint-staged/lint-staged-config.constant.spec.ts
@@ -1,6 +1,6 @@
 import * as PackageJsonUtils from '../../../utils/package-json.utils.js';
-import { EslintPackage } from '../eslint/index.js';
-import { PrettierPackage } from '../prettier/index.js';
+import { EslintPackage } from '../eslint';
+import { PrettierPackage } from '../prettier';
 import { CONFIG, CONFIG_NAME } from './lint-staged-config.constant.js';
 
 describe('lint-staged constant', () => {

--- a/packages/cli/src/components/packages/prettier/prettier.package.spec.ts
+++ b/packages/cli/src/components/packages/prettier/prettier.package.spec.ts
@@ -2,6 +2,7 @@ import { fileSystem } from '../../../services/node/file-system.service.js';
 import * as packageUtils from '../../../utils/package-json.utils.js';
 import { PrettierPackage } from './prettier.package.js';
 
+jest.mock('../../../services/node/child-process.service.js');
 jest.mock('../../../services/node/file-system.service.js');
 jest.mock('../../../utils/package-json.utils.js');
 

--- a/packages/cli/src/constants/husky-cli.constant.ts
+++ b/packages/cli/src/constants/husky-cli.constant.ts
@@ -1,5 +1,7 @@
-export const COMMIT_MSG_COMMITLINT = 'npx --no -- commitlint --edit ${1}';
-export const PRE_COMMIT_LINT_STAGED = 'npx lint-staged';
+import { PackageManagerService } from '../services/package-manager/package-manager.service.js';
+
+export const COMMIT_MSG_COMMITLINT = `${new PackageManagerService().exec} --no -- commitlint --edit $\{1}`;
+export const PRE_COMMIT_LINT_STAGED = `${new PackageManagerService().exec} lint-staged`;
 
 /*
 export const PRE_COMMIT_BIOME_CHECK = 'npx @biomejs/biome check --apply';

--- a/packages/cli/src/constants/husky-cli.constant.ts
+++ b/packages/cli/src/constants/husky-cli.constant.ts
@@ -1,10 +1,6 @@
 import { PackageManagerService } from '../services/package-manager/package-manager.service.js';
 
-export const COMMIT_MSG_COMMITLINT = `${new PackageManagerService().exec} --no -- commitlint --edit $\{1}`;
-export const PRE_COMMIT_LINT_STAGED = `${new PackageManagerService().exec} lint-staged`;
+const CLI = new PackageManagerService().cli;
 
-/*
-export const PRE_COMMIT_BIOME_CHECK = 'npx @biomejs/biome check --apply';
-export const PRE_COMMIT_BIOME_FORMAT = `npx @biomejs/biome format --write`;
-export const PRE_COMMIT_BIOME_LINT = 'npx @biomejs/biome lint';
-*/
+export const COMMIT_MSG_COMMITLINT = `${CLI.exec} --no -- commitlint --edit $\{1}`;
+export const PRE_COMMIT_LINT_STAGED = `${CLI.exec} lint-staged`;

--- a/packages/cli/src/services/initializer.service.ts
+++ b/packages/cli/src/services/initializer.service.ts
@@ -15,7 +15,6 @@ export class InitializerService {
     const packagesToInstall: PackagesDependencyGroup = {
       dependency: [],
       devDependency: [],
-      global: [],
     };
     const packagesToInit: Package[] = [];
 
@@ -29,10 +28,6 @@ export class InitializerService {
           packagesToInstall.devDependency.push(package_.dependency);
           break;
         }
-        case 'global': {
-          packagesToInstall.global.push(package_.dependency);
-          break;
-        }
         case 'none': {
           packagesToInit.push(package_.package);
           break;
@@ -41,7 +36,7 @@ export class InitializerService {
     }
 
     await this.#packageManagerService.install(packagesToInstall);
-    await this.#packageManagerService.create(packagesToInit);
+    await this.#packageManagerService.init(packagesToInit);
   }
 
   configure(): Promise<void> {

--- a/packages/cli/src/services/node/file-system.service.ts
+++ b/packages/cli/src/services/node/file-system.service.ts
@@ -12,13 +12,7 @@ export class FileSystemService {
     });
   }
 
-  writeFile(
-    fileName: string,
-    content: string,
-    callback = () => {
-      /**/
-    }
-  ): void {
+  writeFile(fileName: string, content: string): void {
     fs.writeFileSync(fileName, content);
   }
 

--- a/packages/cli/src/services/node/file-system.service.ts
+++ b/packages/cli/src/services/node/file-system.service.ts
@@ -19,7 +19,7 @@ export class FileSystemService {
       /**/
     }
   ): void {
-    fs.writeFile(fileName, content, callback);
+    fs.writeFileSync(fileName, content);
   }
 
   appendFileSync(fileName: string, content: string): void {

--- a/packages/cli/src/services/package-manager/package-manager.service.spec.ts
+++ b/packages/cli/src/services/package-manager/package-manager.service.spec.ts
@@ -1,12 +1,14 @@
-import { InstallationType } from '../../type/enums/installation-type.enum';
+import type { PackageManagerInterface } from '../../type/interfaces/package-manager.interface.js';
+import type { PackageManagerType } from '../../type/types/package-manager-type.type.js';
 import { Package } from '../../type/types/packages.type.js';
+import * as packageManagerUtils from '../../utils/package-manager.utils.js';
 import * as childProcess from '../node/child-process.service.js';
-import * as fileSystem from '../node/file-system.service.js';
 import { PackageManagerService } from './package-manager.service.js';
+import { PackagerFactory } from './packager.factory.js';
+import { NpmManager, PnpmManager } from './packager-managers';
 
 jest.mock('../node/file-system.service.js');
 jest.mock('../node/child-process.service.js');
-
 describe('PackageManagerService', () => {
   let fixture: PackageManagerService;
 
@@ -18,66 +20,83 @@ describe('PackageManagerService', () => {
     jest.resetAllMocks();
   });
 
-  describe.each([{ packageManager: 'pnpm' }, { packageManager: 'npm' }])(
-    'should do action for $packageManager',
-    ({ packageManager }) => {
-      beforeEach(() => {
-        jest
-          .spyOn(fileSystem.fileSystem, 'queryFileName')
-          .mockImplementation(() => {
-            return packageManager === 'npm' ? undefined : packageManager;
-          });
+  describe.each([
+    { PM: 'pnpm', PMInstance: new PnpmManager() },
+    { PM: 'npm', PMInstance: new NpmManager() },
+  ] satisfies {
+    PM: PackageManagerType;
+    PMInstance: PackageManagerInterface;
+  }[])('should do action for $PM', ({ PM, PMInstance }) => {
+    beforeEach(() => {
+      jest
+        .spyOn(packageManagerUtils, 'detectPackageManager')
+        .mockReturnValue(PM);
+      jest
+        .spyOn(PackagerFactory.prototype, 'createPackagerManager')
+        .mockReturnValue(PMInstance);
+      fixture = new PackageManagerService();
+    });
 
-        fixture = new PackageManagerService();
+    describe('install', () => {
+      it('should call execAsync for each installation type', async () => {
+        const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
+
+        await fixture.install({
+          dependency: ['SomePackage'] as unknown as Package[],
+          devDependency: ['AnotherPackage'] as unknown as Package[],
+        } as never);
+
+        const resultsExpected = [
+          `${PMInstance.cli.install} ${PMInstance.dependencyInstallation.dependency} SomePackage`,
+          `${PMInstance.cli.install} ${PMInstance.dependencyInstallation.devDependency} AnotherPackage`,
+        ];
+
+        expect(spy).toHaveBeenCalledTimes(resultsExpected.length);
+        for (const [id, expected] of resultsExpected.entries()) {
+          expect(spy).toHaveBeenNthCalledWith(id + 1, expected);
+        }
       });
-      describe('install', () => {
-        it('should call execAsync for each installation type', async () => {
-          const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
+    });
+    describe('init', () => {
+      it('should call execAsync to init automatically config', async () => {
+        const mockPackageNameS = ['test'] as never;
+        const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
 
-          await fixture.install({
-            dependency: ['SomePackage'] as unknown as Package[],
-            devDependency: ['AnotherPackage'] as unknown as Package[],
-            global: ['ThirdPackage'] as unknown as Package[],
-          } as never);
+        await fixture.init(mockPackageNameS);
 
-          const resultsExpected = [
-            `${packageManager} add ${InstallationType.dependency} SomePackage`,
-            `${packageManager} add ${InstallationType.developmentDependency} AnotherPackage`,
-            `${packageManager} add ${InstallationType.global} ThirdPackage`,
-          ];
-
-          expect(spy).toHaveBeenCalledTimes(resultsExpected.length);
-          for (const [id, expected] of resultsExpected.entries()) {
-            expect(spy).toHaveBeenNthCalledWith(id + 1, expected);
+        expect(spy).toHaveBeenCalledTimes(1);
+        switch (PM) {
+          case 'npm': {
+            expect(spy).toHaveBeenCalledWith(`${PMInstance.cli.init} test`, {
+              stderr: false,
+            });
+            break;
           }
-        });
+          case 'pnpm': {
+            expect(spy).toHaveBeenCalledWith(
+              `${PMInstance.cli.init} create-test`,
+              {
+                stderr: false,
+              }
+            );
+            break;
+          }
+        }
       });
+    });
 
-      describe('create', () => {
-        it('should call execAsync to create automatically config', async () => {
-          const mockPackageNameS = ['test'] as never;
-          const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
+    describe('uninstall', () => {
+      it('should call execAsync', async () => {
+        const mockPackageNameS = ['test', '123'] as never;
+        const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
 
-          await fixture.create(mockPackageNameS);
+        await fixture.uninstall(mockPackageNameS);
 
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spy).toHaveBeenCalledWith(`${packageManager} create test`, {
-            stderr: false,
-          });
-        });
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(
+          `${PMInstance.cli.uninstall} test 123`
+        );
       });
-
-      describe('uninstall', () => {
-        it('should call execAsync', async () => {
-          const mockPackageNameS = ['test', '123'] as never;
-          const spy = jest.spyOn(childProcess.childProcess, 'execAsync');
-
-          await fixture.uninstall(mockPackageNameS);
-
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spy).toHaveBeenCalledWith(`${packageManager} remove test 123`);
-        });
-      });
-    }
-  );
+    });
+  });
 });

--- a/packages/cli/src/services/package-manager/package-manager.service.ts
+++ b/packages/cli/src/services/package-manager/package-manager.service.ts
@@ -5,11 +5,11 @@ import type {
 } from '../../type/interfaces/package-manager.interface.js';
 import type { PackagesDependencyGroup } from '../../type/types/packages-dependency-group.interface.js';
 import { detectPackageManager } from '../../utils/package-manager.utils.js';
-import { PackagerFactoryService } from './packager-factory.service.js';
+import { PackagerFactory } from './packager.factory.js';
 
 export class PackageManagerService {
   #packageManager: PackageManagerInterface =
-    new PackagerFactoryService().createPackagerManager(detectPackageManager());
+    new PackagerFactory().createPackagerManager(detectPackageManager());
 
   get cli(): CLI {
     return this.#packageManager.cli;

--- a/packages/cli/src/services/package-manager/package-manager.service.ts
+++ b/packages/cli/src/services/package-manager/package-manager.service.ts
@@ -3,11 +3,19 @@ import type {
   CLI,
   PackageManagerInterface,
 } from '../../type/interfaces/package-manager.interface.js';
+import type { DependencyTypeToInstall } from '../../type/types/dependency-type.type.js';
+import type { Dependency } from '../../type/types/package-version.type.js';
 import type { PackagesDependencyGroup } from '../../type/types/packages-dependency-group.interface.js';
 import { detectPackageManager } from '../../utils/package-manager.utils.js';
 import { PackagerFactory } from './packager.factory.js';
 
-export class PackageManagerService {
+export class PackageManagerService
+  implements
+    Omit<
+      PackageManagerInterface,
+      'dependencyInstallation' | 'init' | 'install'
+    >
+{
   #packageManager: PackageManagerInterface =
     new PackagerFactory().createPackagerManager(detectPackageManager());
 
@@ -15,15 +23,13 @@ export class PackageManagerService {
     return this.#packageManager.cli;
   }
 
-  async install({
-    dependency = [],
-    devDependency = [],
-  }: PackagesDependencyGroup) {
-    if (dependency.length > 0)
-      await this.#packageManager.install(dependency, 'dependency');
-    if (devDependency.length > 0)
-      await this.#packageManager.install(devDependency, 'devDependency');
-  }
+  // Provided methods
+  readonly set = (value: string): void => this.#packageManager.set(value);
+  readonly exec = (value: string): void => this.#packageManager.exec(value);
+  readonly uninstall = async (packages: string[]): Promise<void> =>
+    await this.#packageManager.uninstall(packages);
+
+  // End Provided methods
 
   async init(packages: string[]): Promise<void> {
     for (const _package of packages)
@@ -34,15 +40,24 @@ export class PackageManagerService {
       }
   }
 
-  async uninstall(packages: string[]): Promise<void> {
-    await this.#packageManager.uninstall(packages);
+  async install({
+    dependency = [],
+    devDependency = [],
+  }: PackagesDependencyGroup): Promise<void> {
+    await this.installPackages(dependency, 'dependency');
+    await this.installPackages(devDependency, 'devDependency');
   }
 
-  set(value: string): void {
-    this.#packageManager.set(value);
-  }
-
-  exec(value: string): void {
-    this.#packageManager.exec(value);
+  private async installPackages(
+    packages: Dependency[],
+    type: DependencyTypeToInstall
+  ): Promise<void> {
+    if (packages.length > 0) {
+      try {
+        await this.#packageManager.install(packages, type);
+      } catch (error) {
+        console.error(error);
+      }
+    }
   }
 }

--- a/packages/cli/src/services/package-manager/package-manager.service.ts
+++ b/packages/cli/src/services/package-manager/package-manager.service.ts
@@ -1,73 +1,48 @@
 /* eslint-disable unicorn/prevent-abbreviations */
-import { InstallationType } from '../../type/enums/installation-type.enum.js';
-import type { Dependency } from '../../type/types/package-version.type.js';
-import type { Package } from '../../type/types/packages.type.js';
+import type {
+  CLI,
+  PackageManagerInterface,
+} from '../../type/interfaces/package-manager.interface.js';
 import type { PackagesDependencyGroup } from '../../type/types/packages-dependency-group.interface.js';
-import { childProcess } from '../node/child-process.service.js';
-import { fileSystem } from '../node/file-system.service.js';
-
-// @Todo add support for YARN
-type PackageManager = 'npm' | 'pnpm';
+import { detectPackageManager } from '../../utils/package-manager.utils.js';
+import { PackagerFactoryService } from './packager-factory.service.js';
 
 export class PackageManagerService {
-  #packageManager: PackageManager = this.#selectPackageManager();
+  #packageManager: PackageManagerInterface =
+    new PackagerFactoryService().createPackagerManager(detectPackageManager());
+
+  get cli(): CLI {
+    return this.#packageManager.cli;
+  }
 
   async install({
     dependency = [],
     devDependency = [],
-    global = [],
   }: PackagesDependencyGroup) {
-    await this.#installPackages(dependency, InstallationType.dependency);
-    await this.#installPackages(
-      devDependency,
-      InstallationType.developmentDependency
-    );
-    await this.#installPackages(global, InstallationType.global);
+    if (dependency.length > 0)
+      await this.#packageManager.install(dependency, 'dependency');
+    if (devDependency.length > 0)
+      await this.#packageManager.install(devDependency, 'devDependency');
   }
 
-  /**
-   * @example set('scripts.test`, 'echo "test"')
-   * */
-  set(value: string): void {
-    childProcess.execSync(`${this.#packageManager} pkg set ${value}`);
-  }
-
-  async create(packages: Package[]): Promise<void> {
+  async init(packages: string[]): Promise<void> {
     for (const _package of packages)
       try {
-        await childProcess.execAsync(
-          `${this.#packageManager} create ${_package}`,
-          {
-            stderr: false,
-          }
-        );
+        await this.#packageManager.init(_package);
       } catch (error) {
         console.error(error);
       }
   }
 
   async uninstall(packages: string[]): Promise<void> {
-    const dependencies = packages.join(' ');
-    await childProcess.execAsync(
-      `${this.#packageManager} remove ${dependencies}`
-    );
+    await this.#packageManager.uninstall(packages);
   }
 
-  #selectPackageManager(): PackageManager {
-    if (fileSystem.queryFileName('pnpm-lock.yaml')) return 'pnpm';
-    return 'npm';
+  set(value: string): void {
+    this.#packageManager.set(value);
   }
 
-  async #installPackages(
-    packages: Dependency[],
-    type: InstallationType
-  ): Promise<void> {
-    if (packages.length === 0) {
-      return;
-    }
-    const dependencies = packages.join(' ');
-    await childProcess.execAsync(
-      `${this.#packageManager} add ${type} ${dependencies}`
-    );
+  exec(value: string): void {
+    this.#packageManager.exec(value);
   }
 }

--- a/packages/cli/src/services/package-manager/packager-factory.service.ts
+++ b/packages/cli/src/services/package-manager/packager-factory.service.ts
@@ -1,0 +1,24 @@
+import type { PackageManagerInterface } from '../../type/interfaces/package-manager.interface.js';
+import type { PackageManagerType } from '../../type/types/package-manager-type.type.js';
+import { NpmManager } from './packager-managers/npm.manager.js';
+import { PnpmManager } from './packager-managers/pnpm.manager.js';
+
+export class PackagerFactoryService {
+  createPackagerManager(
+    type: PackageManagerType | undefined
+  ): PackageManagerInterface {
+    switch (type) {
+      case 'npm': {
+        return new NpmManager();
+      }
+
+      case 'pnpm': {
+        return new PnpmManager();
+      }
+
+      default: {
+        throw new Error(`Unsupported package manager type`);
+      }
+    }
+  }
+}

--- a/packages/cli/src/services/package-manager/packager-managers/index.ts
+++ b/packages/cli/src/services/package-manager/packager-managers/index.ts
@@ -1,0 +1,2 @@
+export * from './npm.manager.js';
+export * from './pnpm.manager.js';

--- a/packages/cli/src/services/package-manager/packager-managers/npm.manager.ts
+++ b/packages/cli/src/services/package-manager/packager-managers/npm.manager.ts
@@ -11,7 +11,7 @@ export class NpmManager implements PackageManagerInterface {
   readonly cli: CLI = {
     install: 'npm i',
     set: `npm pkg set`,
-    exec: `npm exec`,
+    exec: `npx`,
     uninstall: `npm uninstall`,
     init: `npm init`,
   };

--- a/packages/cli/src/services/package-manager/packager-managers/npm.manager.ts
+++ b/packages/cli/src/services/package-manager/packager-managers/npm.manager.ts
@@ -1,0 +1,50 @@
+import type {
+  CLI,
+  DependencyInstallation,
+  PackageManagerInterface,
+} from '../../../type/interfaces/package-manager.interface.js';
+import type { DependencyTypeToInstall } from '../../../type/types/dependency-type.type.js';
+import type { Dependency } from '../../../type/types/package-version.type.js';
+import { childProcess } from '../../node/child-process.service.js';
+
+export class NpmManager implements PackageManagerInterface {
+  readonly cli: CLI = {
+    install: 'npm i',
+    set: `npm pkg set`,
+    exec: `npm exec`,
+    uninstall: `npm uninstall`,
+    init: `npm init`,
+  };
+
+  readonly dependencyInstallation: DependencyInstallation = {
+    dependency: '--save-prod',
+    devDependency: '--save-dev',
+  };
+
+  async install(
+    packages: Dependency[],
+    type: DependencyTypeToInstall
+  ): Promise<void> {
+    await childProcess.execAsync(
+      `${this.cli.install} ${this.dependencyInstallation[type]} ${packages.join(' ')}`
+    );
+  }
+
+  set(value: string): void {
+    childProcess.execSync(`${this.cli.set} ${value}`);
+  }
+
+  exec(value: string) {
+    childProcess.execSync(`${this.cli.exec} ${value}`);
+  }
+
+  async uninstall(packages: string[]): Promise<void> {
+    await childProcess.execAsync(`${this.cli.uninstall} ${packages.join(' ')}`);
+  }
+
+  async init(dependency: string): Promise<void> {
+    await childProcess.execAsync(`${this.cli.init} ${dependency}`, {
+      stderr: false,
+    });
+  }
+}

--- a/packages/cli/src/services/package-manager/packager-managers/pnpm.manager.ts
+++ b/packages/cli/src/services/package-manager/packager-managers/pnpm.manager.ts
@@ -11,7 +11,7 @@ export class PnpmManager implements PackageManagerInterface {
   readonly cli: CLI = {
     install: 'pnpm add',
     set: `pnpm pkg set`,
-    exec: `pnpm exec`,
+    exec: `pnpm`,
     uninstall: `pnpm remove`,
     init: `pnpm dlx`,
   };

--- a/packages/cli/src/services/package-manager/packager-managers/pnpm.manager.ts
+++ b/packages/cli/src/services/package-manager/packager-managers/pnpm.manager.ts
@@ -1,0 +1,61 @@
+import type {
+  CLI,
+  DependencyInstallation,
+  PackageManagerInterface,
+} from '../../../type/interfaces/package-manager.interface.js';
+import type { DependencyTypeToInstall } from '../../../type/types/dependency-type.type.js';
+import type { Dependency } from '../../../type/types/package-version.type.js';
+import { childProcess } from '../../node/child-process.service.js';
+
+export class PnpmManager implements PackageManagerInterface {
+  readonly cli: CLI = {
+    install: 'pnpm add',
+    set: `pnpm pkg set`,
+    exec: `pnpm exec`,
+    uninstall: `pnpm remove`,
+    init: `pnpm dlx`,
+  };
+
+  readonly dependencyInstallation: DependencyInstallation = {
+    dependency: '--save-prod',
+    devDependency: '--save-dev',
+  };
+
+  async install(
+    packages: Dependency[],
+    type: DependencyTypeToInstall
+  ): Promise<void> {
+    await childProcess.execAsync(
+      `${this.cli.install} ${this.dependencyInstallation[type]} ${packages.join(' ')}`
+    );
+  }
+
+  set(value: string): void {
+    childProcess.execSync(`${this.cli.set} ${value}`);
+  }
+
+  async uninstall(packages: string[]): Promise<void> {
+    await childProcess.execAsync(`${this.cli.uninstall} ${packages.join(' ')}`);
+  }
+
+  exec(value: string) {
+    childProcess.execSync(`${this.cli.exec} ${value}`);
+  }
+
+  async init(dependency: string): Promise<void> {
+    await childProcess.execAsync(
+      `${this.cli.init} ${this.#addCreateWord(dependency)}`,
+      {
+        stderr: false,
+      }
+    );
+  }
+
+  #addCreateWord(
+    dependency: string
+  ): `${string}/create-${string}` | `create-${string}` {
+    const value = dependency.split('/');
+    if (value.length > 1) return `${value[0]}/create-${value[1]}`;
+    return `create-${value[0]}`;
+  }
+}

--- a/packages/cli/src/services/package-manager/packager.factory.ts
+++ b/packages/cli/src/services/package-manager/packager.factory.ts
@@ -1,9 +1,8 @@
 import type { PackageManagerInterface } from '../../type/interfaces/package-manager.interface.js';
 import type { PackageManagerType } from '../../type/types/package-manager-type.type.js';
-import { NpmManager } from './packager-managers/npm.manager.js';
-import { PnpmManager } from './packager-managers/pnpm.manager.js';
+import { NpmManager, PnpmManager } from './packager-managers/index.js';
 
-export class PackagerFactoryService {
+export class PackagerFactory {
   createPackagerManager(
     type: PackageManagerType | undefined
   ): PackageManagerInterface {

--- a/packages/cli/src/services/packages/husky/husky.service.ts
+++ b/packages/cli/src/services/packages/husky/husky.service.ts
@@ -1,4 +1,5 @@
 import { childProcess } from '../../node/child-process.service.js';
+import { PackageManagerService } from '../../package-manager/package-manager.service.js';
 
 export class HuskyService {
   /**
@@ -14,7 +15,7 @@ export class HuskyService {
   }
 
   init(): void {
-    childProcess.execSync('npx husky init');
+    new PackageManagerService().exec('husky init');
   }
 }
 

--- a/packages/cli/src/type/enums/installation-type.enum.ts
+++ b/packages/cli/src/type/enums/installation-type.enum.ts
@@ -1,5 +1,0 @@
-export enum InstallationType {
-  dependency = '',
-  developmentDependency = '-D',
-  global = '--global',
-}

--- a/packages/cli/src/type/interfaces/package-manager.interface.ts
+++ b/packages/cli/src/type/interfaces/package-manager.interface.ts
@@ -1,0 +1,31 @@
+import type { DependencyTypeToInstall } from '../types/dependency-type.type.js';
+import type { Dependency } from '../types/package-version.type.js';
+
+export type DependencyInstallation = {
+  readonly [key in DependencyTypeToInstall]: string;
+};
+
+type _CLI = 'install' | 'set' | 'exec' | 'uninstall' | 'init';
+
+export type CLI = {
+  readonly [key in _CLI]: string;
+};
+export interface PackageManagerInterface {
+  readonly cli: CLI;
+  readonly dependencyInstallation: DependencyInstallation;
+
+  /**
+   * installation command
+   * @example install('confiks', 'devDependency')
+   */
+  install(packages: Dependency[], type: DependencyTypeToInstall): Promise<void>;
+
+  /**
+   * script to set values in pkg
+   * @example set('scripts.test`, 'echo "test"')
+   * */
+  set(value: string): void;
+  exec(value: string): void;
+  uninstall(packages: string[]): Promise<void>;
+  init(packages: string): Promise<void>;
+}

--- a/packages/cli/src/type/types/dependency-type.type.ts
+++ b/packages/cli/src/type/types/dependency-type.type.ts
@@ -3,7 +3,5 @@
  * @see https://www.geeksforgeeks.org/what-is-the-meaning-of-save-for-npm-install/
  * */
 
-type DependencyTypes = ['none', 'dependency', 'devDependency', 'global'];
-
-export type DependencyType = DependencyTypes[number];
-export type DependencyTypeToInstall = DependencyType[1 | 2 | 3];
+export type DependencyTypeToInstall = 'dependency' | 'devDependency';
+export type DependencyType = DependencyTypeToInstall | 'none';

--- a/packages/cli/src/type/types/package-manager-type.type.ts
+++ b/packages/cli/src/type/types/package-manager-type.type.ts
@@ -1,0 +1,1 @@
+export type PackageManagerType = /*'bun' | 'bunx' | 'yarn' |*/ 'pnpm' | 'npm';

--- a/packages/cli/src/utils/package-manager.utils.ts
+++ b/packages/cli/src/utils/package-manager.utils.ts
@@ -1,0 +1,20 @@
+import type { PackageManagerType } from '../type/types/package-manager-type.type.js';
+
+let _manager: PackageManagerType | undefined;
+export function detectPackageManager(): PackageManagerType | undefined {
+  if (_manager) return _manager;
+  const userAgent = process.env.npm_config_user_agent ?? '';
+  const argv = process.argv.join(' ');
+
+  const packageManagers: PackageManagerType[] = ['pnpm', 'npm'];
+  const manager = packageManagers.find(
+    name => userAgent.includes(name) || argv.includes(name)
+  );
+  if (manager) {
+    _manager = manager;
+    return manager;
+  }
+
+  _manager = undefined;
+  return undefined;
+}

--- a/packages/cli/src/utils/package-manager.utils.ts
+++ b/packages/cli/src/utils/package-manager.utils.ts
@@ -10,11 +10,6 @@ export function detectPackageManager(): PackageManagerType | undefined {
   const manager = packageManagers.find(
     name => userAgent.includes(name) || argv.includes(name)
   );
-  if (manager) {
-    _manager = manager;
-    return manager;
-  }
-
-  _manager = undefined;
-  return undefined;
+  _manager = manager;
+  return manager;
 }


### PR DESCRIPTION
Additionally:
- refactor code
- add script to run configurator via pnpm cli
- fix biome config init script
- remove unused global installation
- fix typo in base.package.ts
- remove comments in husky.constants
- writeFile => writeFileSync

Tests:
- add jest.mock for some files
- improve tests for packager-mangaer.service